### PR TITLE
add board class and create cells hash

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,0 +1,18 @@
+class Board
+
+attr_reader :cells
+
+    def initialize
+        @cells = {}
+        create_cells
+    end
+
+    def create_cells
+        ("A".."D").each do |letter|
+            (1..4).each do |number|
+                coordinate = "#{letter}#{number}"
+                cells[coordinate] = Cell.new(coordinate)
+            end
+        end
+    end
+end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -1,0 +1,21 @@
+require './lib/board'
+require './lib/ship'
+require './lib/cell'
+require 'pry'
+
+RSpec.describe Board do
+    before(:each) do
+        @board = Board.new
+    end
+
+    describe '#initialze' do
+        it "exists" do
+            expect(@board).to be_instance_of(Board)
+        end
+
+        it 'is a hash' do
+            binding.pry
+            expect(@board.cells).to be_a(Hash)
+        end
+    end
+end


### PR DESCRIPTION
This pull request adds the board class and creates a cells hash.

Summary of changes:
1. Create board class to keep track of cells
2. Initialize the board class with a hash of Cell objects